### PR TITLE
replace broken URL with functioning example

### DIFF
--- a/js/staticmap.js
+++ b/js/staticmap.js
@@ -14,7 +14,7 @@ define([
 
                 this.printService = options.printService || "https://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"; // default seat geek range is 30mi
 
-                esriConfig.defaults.io.corsEnabledServers.push("sampleserver6.arcgisonline.com");
+                esriConfig.defaults.io.corsEnabledServers.push("https://utility.arcgisonline.com");
 
                 that = this;
             },

--- a/js/staticmap.js
+++ b/js/staticmap.js
@@ -12,7 +12,7 @@ define([
             constructor: function(options){
                 options = options || {};
 
-                this.printService = options.printService || "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"; // default seat geek range is 30mi
+                this.printService = options.printService || "https://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"; // default seat geek range is 30mi
 
                 esriConfig.defaults.io.corsEnabledServers.push("sampleserver6.arcgisonline.com");
 


### PR DESCRIPTION
for some reason the old SampleServer6 printing service is failing - you can see this in the demo at http://esri-es.github.io/Static-Maps-API-ArcGIS/